### PR TITLE
Added special sats psbt method

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## [0.2.12]
+- `Inscription`
+  - Updated `createSpecialSatsPSBT` - method request and response to create special sats psbt with XVerse wallet support.
+
 ## [0.2.11]
 - `Inscription`
   - Updated `createDirectOrder` - method to create multi parent parent child inscription order.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ordinalsbot",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Node.js library for OrdinalsBot API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/types/v1.ts
+++ b/src/types/v1.ts
@@ -782,9 +782,24 @@ export interface InscriptionReferralSetResponse {
  */
 export interface CreateSpecialSatsResponse {
   /**
-   * base64 transaction to be signed
+   * The PSBT in Base64 format.
    */
-  psbt: string;
+  psbtBase64: string;
+
+  /**
+   * The indices of the inputs related to ordinals.
+   */
+  ordinalInputIndices: Array<number>;
+
+  /**
+   * The indices of the inputs related to payments.
+   */
+  paymentInputIndices: Array<number>;
+
+  /**
+   * The PSBT in hexadecimal format.
+   */
+  psbtHex: string;
 }
 
 /**
@@ -801,13 +816,24 @@ export interface CreateSpecialSatsRequest {
   specialSatsOutput: string;
 
   /** user's payment address */
-  userAddress: string;
+  paymentAddress: string;
 
   /** user's payment public key*/
-  userPublicKey: string;
+  paymentPublicKey: string;
+  
+  /** user's ordinal address */
+  ordinalAddress: string;
 
+  /** user's ordinal public key*/
+  ordinalPublicKey: string;
+  
   /**feeRate */
   feeRate: number;
+
+  /**
+   * The provider of the user's wallet. This field is optional.
+   */
+  walletProvider?: string;
 }
 
 // Order states enum


### PR DESCRIPTION
- Added `createSpecialSatsPSBT` method to create a PSBT, which needs to be signed and broadcast by the user to pay for a special sats inscription order
- Added optional XVerse argument to `createSpecialSatsPSBT` for wallet signing and broadcast when using the module on the frontend